### PR TITLE
Extend the test case of bugfix #140

### DIFF
--- a/src/useWatchSweety.ts
+++ b/src/useWatchSweety.ts
@@ -59,11 +59,11 @@ export function useWatchSweety<T>(
   // so the getState will be consistent over multiple calls until the real change happens
   // when the version changes the select function calls the watcher and extracts actual data
   // without that workaround it will go to the re-render hell
-  const subscribe = useCallback((onStoreChange: VoidFunction) => {
+  const subscribe = useEvent((onStoreChange: VoidFunction) => {
     onStoreChangeRef.current = onStoreChange
 
     return unsubscribeRef.current!
-  }, [])
+  })
 
   const getState = useCallback(() => watcherUpdateVersionRef.current, [])
 

--- a/src/useWatchSweety.ts
+++ b/src/useWatchSweety.ts
@@ -26,7 +26,7 @@ export function useWatchSweety<T>(
 ): T {
   const watcherUpdateVersionRef = useRef(0)
   const contextRef = useRef<WatchContext>()
-  const unsubscribeRef = useRef<VoidFunction>()
+  const subscribeRef = useRef<(onStoreChange: VoidFunction) => VoidFunction>()
   const onStoreChangeRef = useRef<null | VoidFunction>(null)
 
   if (contextRef.current == null) {
@@ -43,28 +43,28 @@ export function useWatchSweety<T>(
 
   // it should subscribe the WatchContext during render otherwise
   // it might lead to race conditions with useEffect(() => Sweety#setState())
-  if (unsubscribeRef.current == null) {
-    unsubscribeRef.current = contextRef.current.subscribeOnWatchedStores(() => {
+  if (subscribeRef.current == null) {
+    const unsubscribe = contextRef.current.subscribeOnWatchedStores(() => {
       watcherUpdateVersionRef.current = modInc(watcherUpdateVersionRef.current)
 
       // it should return the onStoreChange callback to call it during the WatchContext#cycle()
       // when the callback is null the cycle does not call so watched stores do not unsubscribe
       return onStoreChangeRef.current
     })
+
+    subscribeRef.current = (onStoreChange) => {
+      onStoreChangeRef.current = onStoreChange
+
+      return unsubscribe
+    }
   }
 
-  // the subscribe cannot directly return the watcher result
+  // the getState cannot directly return the watcher result
   // because it might be different per each call
   // instead it increments the watcherUpdateVersionRef each time when any watched store changes
   // so the getState will be consistent over multiple calls until the real change happens
   // when the version changes the select function calls the watcher and extracts actual data
   // without that workaround it will go to the re-render hell
-  const subscribe = useEvent((onStoreChange: VoidFunction) => {
-    onStoreChangeRef.current = onStoreChange
-
-    return unsubscribeRef.current!
-  })
-
   const getState = useCallback(() => watcherUpdateVersionRef.current, [])
 
   // the select calls each time when updates either the watcher or the watcherUpdateVersionRef
@@ -77,7 +77,7 @@ export function useWatchSweety<T>(
   const onCompare = useEvent(compare ?? isEqual)
 
   const value = useSyncExternalStoreWithSelector(
-    subscribe,
+    subscribeRef.current,
     getState,
     getState,
     select,

--- a/src/useWatchSweety.ts
+++ b/src/useWatchSweety.ts
@@ -24,10 +24,9 @@ export function useWatchSweety<T>(
   watcher: () => T,
   compare?: null | Compare<T>,
 ): T {
-  const watcherUpdateVersionRef = useRef(0)
   const contextRef = useRef<WatchContext>()
   const subscribeRef = useRef<(onStoreChange: VoidFunction) => VoidFunction>()
-  const onStoreChangeRef = useRef<null | VoidFunction>(null)
+  const getStateRef = useRef<() => number>(null as never)
 
   if (contextRef.current == null) {
     contextRef.current = new WatchContext()
@@ -44,30 +43,33 @@ export function useWatchSweety<T>(
   // it should subscribe the WatchContext during render otherwise
   // it might lead to race conditions with useEffect(() => Sweety#setState())
   if (subscribeRef.current == null) {
+    let version = 0
+    let onWatchedStoresUpdate: null | VoidFunction = null
+
+    // the getState cannot directly return the watcher result
+    // because it might be different per each call
+    // instead it increments the version each time when any watched store changes
+    // so the getState will be consistent over multiple calls until the real change happens
+    // when the version changes the select function calls the watcher and extracts actual data
+    // without that workaround it will go to the re-render hell
+    getStateRef.current = () => version
+
     const unsubscribe = contextRef.current.subscribeOnWatchedStores(() => {
-      watcherUpdateVersionRef.current = modInc(watcherUpdateVersionRef.current)
+      version = modInc(version)
 
       // it should return the onStoreChange callback to call it during the WatchContext#cycle()
       // when the callback is null the cycle does not call so watched stores do not unsubscribe
-      return onStoreChangeRef.current
+      return onWatchedStoresUpdate
     })
 
     subscribeRef.current = (onStoreChange) => {
-      onStoreChangeRef.current = onStoreChange
+      onWatchedStoresUpdate = onStoreChange
 
       return unsubscribe
     }
   }
 
-  // the getState cannot directly return the watcher result
-  // because it might be different per each call
-  // instead it increments the watcherUpdateVersionRef each time when any watched store changes
-  // so the getState will be consistent over multiple calls until the real change happens
-  // when the version changes the select function calls the watcher and extracts actual data
-  // without that workaround it will go to the re-render hell
-  const getState = useCallback(() => watcherUpdateVersionRef.current, [])
-
-  // the select calls each time when updates either the watcher or the watcherUpdateVersionRef
+  // the select calls each time when updates either the watcher or the version
   const select = useCallback(
     () => WatchContext.executeWatcher(watcher),
     [watcher],
@@ -78,8 +80,8 @@ export function useWatchSweety<T>(
 
   const value = useSyncExternalStoreWithSelector(
     subscribeRef.current,
-    getState,
-    getState,
+    getStateRef.current,
+    getStateRef.current,
     select,
     onCompare,
   )

--- a/tests/bugfixes.spec.tsx
+++ b/tests/bugfixes.spec.tsx
@@ -1,29 +1,31 @@
 import { act, fireEvent, render, screen } from "@testing-library/react"
 import React from "react"
 
-import { Sweety, useSweetyState, useWatchSweety } from "../src"
+import { Sweety, useGetSweetyState, useWatchSweety } from "../src"
 
 describe("watching misses when defined after useEffect #140", () => {
   interface ComponentProps {
     first: Sweety<number>
     second: Sweety<number>
-    useWatchSecond(second: Sweety<number>): number
+    useGetFirst(first: Sweety<number>): number
+    useGetSecond(second: Sweety<number>): number
   }
 
   const ComponentWatchBeforeEffect: React.FC<ComponentProps> = ({
     first,
     second,
-    useWatchSecond,
+    useGetFirst,
+    useGetSecond,
   }) => {
-    const [x, setX] = useSweetyState(first)
-    const y = useWatchSecond(second)
+    const x = useGetFirst(first)
+    const y = useGetSecond(second)
 
     React.useEffect(() => {
       second.setState(x)
     }, [second, x])
 
     return (
-      <button type="button" onClick={() => setX(x + 1)}>
+      <button type="button" onClick={() => first.setState(x + 1)}>
         {y}
       </button>
     )
@@ -32,78 +34,83 @@ describe("watching misses when defined after useEffect #140", () => {
   const ComponentWatchAfterEffect: React.FC<ComponentProps> = ({
     first,
     second,
-    useWatchSecond,
+    useGetFirst,
+    useGetSecond,
   }) => {
-    const [x, setX] = useSweetyState(first)
+    const x = useGetFirst(first)
 
     React.useEffect(() => {
       second.setState(x)
     }, [second, x])
 
-    const y = useWatchSecond(second)
+    const y = useGetSecond(second)
 
     return (
-      <button type="button" onClick={() => setX(x + 1)}>
+      <button type="button" onClick={() => first.setState(x + 1)}>
         {y}
       </button>
     )
   }
 
+  const useWatchInline = (store: Sweety<number>) => {
+    return useWatchSweety(() => store.getState())
+  }
+
+  const useWatchMemoized = (store: Sweety<number>) => {
+    return useWatchSweety(React.useCallback(() => store.getState(), [store]))
+  }
+
   describe.each([
     ["before", ComponentWatchBeforeEffect],
     ["after", ComponentWatchAfterEffect],
-  ])("useWatchSweety is %s useEffect", (_, Component) => {
-    it.each([
-      [
-        "inline",
-        (second: Sweety<number>) => {
-          return useWatchSweety(() => second.getState())
-        },
-      ],
-      [
-        "memoized",
-        (second: Sweety<number>) => {
-          return useWatchSweety(
-            React.useCallback(() => second.getState(), [second]),
-          )
-        },
-      ],
-    ])("with %s watcher", (__, useWatchSecond) => {
-      const first = Sweety.of(0)
-      const second = Sweety.of(5)
+  ])("calls depending hook %s useEffect", (_, Component) => {
+    describe.each([
+      ["useGetSweetyState", useGetSweetyState],
+      ["inline useWatchSweety", useWatchInline],
+      ["memoized useWatchSweety", useWatchMemoized],
+    ])("with %s as useGetFirst", (__, useGetFirst) => {
+      it.each([
+        ["useGetSweetyState", useGetSweetyState],
+        ["inline useWatchSweety", useWatchInline],
+        ["memoized useWatchSweety", useWatchMemoized],
+      ])("with %s as useGetSecond", (___, useGetSecond) => {
+        const first = Sweety.of(0)
+        const second = Sweety.of(5)
 
-      render(
-        <Component
-          first={first}
-          second={second}
-          useWatchSecond={useWatchSecond}
-        />,
-      )
+        render(
+          <Component
+            first={first}
+            second={second}
+            useGetFirst={useGetFirst}
+            useGetSecond={useGetSecond}
+          />,
+        )
 
-      const button = screen.getByRole("button")
-      expect(button).toHaveTextContent("0")
+        const button = screen.getByRole("button")
+        expect(button).toHaveTextContent("0")
 
-      fireEvent.click(button)
-      expect(button).toHaveTextContent("1")
+        fireEvent.click(button)
+        expect(button).toHaveTextContent("1")
 
-      fireEvent.click(button)
-      expect(button).toHaveTextContent("2")
+        fireEvent.click(button)
+        expect(button).toHaveTextContent("2")
 
-      act(() => {
-        first.setState(10)
+        act(() => {
+          first.setState(10)
+        })
+        expect(button).toHaveTextContent("10")
+
+        fireEvent.click(button)
+        expect(button).toHaveTextContent("11")
+
+        act(() => {
+          second.setState(20)
+        })
+        expect(button).toHaveTextContent("20")
+
+        fireEvent.click(button)
+        expect(button).toHaveTextContent("12")
       })
-      expect(button).toHaveTextContent("10")
-
-      fireEvent.click(button)
-      expect(button).toHaveTextContent("11")
-
-      act(() => {
-        second.setState(20)
-      })
-      expect(button).toHaveTextContent("20")
-
-      fireEvent.click(button)
-      expect(button).toHaveTextContent("12")
     })
   })
 })


### PR DESCRIPTION
It is worth it to run the setup with all kinds of `useSweetyState` and `useWatchSweety` hooks. It ends up in 18 different combinations.