### PR TITLE
Introduce `Sweety#toJSON()` and `Sweety#toString()`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -245,7 +245,11 @@
         "jest/prefer-spy-on": "error",
         "jest/prefer-strict-equal": "error",
         "jest/prefer-todo": "warn",
-        "@typescript-eslint/explicit-function-return-type": "off"
+        "jest/no-focused-tests": "error",
+        "jest/no-commented-out-tests": "error",
+        "jest/consistent-test-it": ["error", { "fn": "it" }],
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "no-undefined": "off"
       }
     }
   ]

--- a/src/Sweety.ts
+++ b/src/Sweety.ts
@@ -75,6 +75,30 @@ export class Sweety<T> {
   }
 
   /**
+   * Return the state when serializing to JSON.
+   * It does not encode the Sweety instance for decoding it back due to runtime parts of the class,
+   * that cannot be serialized as JSON.
+   *
+   * The method is protected in order to make it impossible to make the implicit call.
+   *
+   * @version 2.1.0
+   */
+  protected toJSON(): unknown {
+    return this.value
+  }
+
+  /**
+   * Return the stringified state when a Sweety instance converts to a string.
+   *
+   * The method is protected in order to make it impossible to make the implicit call.
+   *
+   * @version 2.1.0
+   */
+  protected toString(): string {
+    return String(this.value)
+  }
+
+  /**
    * Clones a `Sweety` instance.
    *
    * @param transform an optional function that applies to the current state before cloning. It might be handy when cloning a state that contains mutable values.

--- a/tests/Sweety.spec.ts
+++ b/tests/Sweety.spec.ts
@@ -443,3 +443,76 @@ describe("Sweety#subscribe", () => {
     expect(spy).not.toHaveBeenCalled()
   })
 })
+
+describe("Sweety#toJSON()", () => {
+  it.concurrent("converts state to JSON", () => {
+    const store = Sweety.of({
+      number: 0,
+      string: "biba",
+      boolean: false,
+      undefined: undefined,
+      null: null,
+      array: [1, "boba", true, undefined, null],
+      object: {
+        number: 2,
+        string: "baba",
+        boolean: false,
+        undefined: undefined,
+        null: null,
+      },
+    })
+
+    expect(JSON.stringify(store)).toMatchInlineSnapshot(
+      '"{\\"number\\":0,\\"string\\":\\"biba\\",\\"boolean\\":false,\\"null\\":null,\\"array\\":[1,\\"boba\\",true,null,null],\\"object\\":{\\"number\\":2,\\"string\\":\\"baba\\",\\"boolean\\":false,\\"null\\":null}}"',
+    )
+  })
+
+  it.concurrent("applies replace fields", () => {
+    const store = Sweety.of({ first: 1, second: 2, third: 3 })
+
+    expect(JSON.stringify(store, ["first", "third"])).toMatchInlineSnapshot(
+      '"{\\"first\\":1,\\"third\\":3}"',
+    )
+  })
+
+  it.concurrent("applies replace function", () => {
+    const store = Sweety.of({ first: 1, second: 2, third: 3 })
+
+    expect(
+      JSON.stringify(store, (_key, value: unknown) => {
+        if (typeof value === "number") {
+          return value * 2
+        }
+
+        return value
+      }),
+    ).toMatchInlineSnapshot('"{\\"first\\":2,\\"second\\":4,\\"third\\":6}"')
+  })
+
+  it.concurrent("applies spaces", () => {
+    const store = Sweety.of({ first: 1, second: 2, third: 3 })
+
+    expect(JSON.stringify(store, null, 2)).toMatchInlineSnapshot(
+      `
+      "{
+        \\"first\\": 1,
+        \\"second\\": 2,
+        \\"third\\": 3
+      }"
+    `,
+    )
+  })
+})
+
+describe("Sweety#toString", () => {
+  it.concurrent.each([
+    ["number", 1, "1"],
+    ["boolean", false, "false"],
+    ["null", null, "null"],
+    ["undefined", undefined, "undefined"],
+    ["array", [1, 2, 3], "1,2,3"],
+    ["object", { first: 1 }, "[object Object]"],
+  ])("converts %s state to string", (_, state, expected) => {
+    expect(String(Sweety.of(state))).toBe(expected)
+  })
+})


### PR DESCRIPTION
The changes add protected `Sweety#toJSON()` and `Sweety#toString()` methods.

Resolves #270 