### PR TITLE
SWT-312 Fix the unnecessary subscription

### DIFF
--- a/src/WatchContext.ts
+++ b/src/WatchContext.ts
@@ -46,6 +46,22 @@ export class WatchContext {
     WatchContext.current?.register(store)
   }
 
+  /**
+   * The method allows to ignore the current WatchContext presence as if it is not there.
+   * Helpful when something needs to perform Sweety#getState without subscribing it to the current WatchContext
+   */
+  public static ignore<T>(execute: () => T): T {
+    const currentContext = WatchContext.current
+
+    WatchContext.current = null
+
+    const result = execute()
+
+    WatchContext.current = currentContext
+
+    return result
+  }
+
   private readonly deadCleanups = new Set<string>()
   private readonly cleanups = new Map<string, VoidFunction>()
 

--- a/src/WatchContext.ts
+++ b/src/WatchContext.ts
@@ -69,24 +69,22 @@ export class WatchContext {
 
   private notify: VoidFunction = noop
 
-  public constructor(private warningSource: null | WarningSource) {}
+  public constructor(private readonly warningSource: null | WarningSource) {}
 
   private register<T>(store: Sweety<T>): void {
     if (this.cleanups.has(store.key)) {
       // still alive
       this.deadCleanups.delete(store.key)
     } else {
-      const thisWarningSource = this.warningSource
-
-      this.warningSource = null
-      this.cleanups.set(
-        store.key,
-        store.subscribe(() => {
-          // the listener registers a watcher so the watcher will emit once per (batch) setState
-          SetStateContext.registerWatchContext(this)
-        }),
-      )
-      this.warningSource = thisWarningSource
+      WatchContext.ignore(() => {
+        this.cleanups.set(
+          store.key,
+          store.subscribe(() => {
+            // the listener registers a watcher so the watcher will emit once per (batch) setState
+            SetStateContext.registerWatchContext(this)
+          }),
+        )
+      })
     }
   }
 

--- a/src/useGetSweetyState.ts
+++ b/src/useGetSweetyState.ts
@@ -2,6 +2,7 @@ import { useCallback, useDebugValue } from "react"
 import { useSyncExternalStore } from "use-sync-external-store/shim/index.js"
 
 import type { Sweety } from "./Sweety"
+import { WatchContext } from "./WatchContext"
 
 /**
  * A hook that subscribes to the `sweety` changes and returns the current state.
@@ -11,7 +12,7 @@ import type { Sweety } from "./Sweety"
 export function useGetSweetyState<T>(sweety: Sweety<T>): T {
   const value = useSyncExternalStore(
     useCallback((onStoreChange) => sweety.subscribe(onStoreChange), [sweety]),
-    useCallback(() => sweety.getState(), [sweety]),
+    useCallback(() => WatchContext.ignore(() => sweety.getState()), [sweety]),
   )
 
   useDebugValue(value)


### PR DESCRIPTION
Resolves #312 

The changes introduce `WatchContext.ignore` method that helps to scope the context visibility of the `Sweety#setState` calls.